### PR TITLE
Add symmetric transform estimation to ICP

### DIFF
--- a/include/cilantro/icp_common_instances.hpp
+++ b/include/cilantro/icp_common_instances.hpp
@@ -81,6 +81,14 @@ namespace cilantro {
                     : DefaultCombinedMetricICPEntities<TransformT,CorrSearchT>(dst_points, src_points),
                       DefaultCombinedMetricICP<TransformT,CorrSearchT>(dst_points, dst_normals, src_points, this->corr_search_, this->point_corr_weight_eval_, this->plane_corr_weight_eval_)
             {}
+
+            SimpleCombinedMetricICPWrapper(const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &dst_points,
+                                           const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &dst_normals,
+                                           const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &src_points,
+                                           const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &src_normals)
+                    : DefaultCombinedMetricICPEntities<TransformT,CorrSearchT>(dst_points, src_points),
+                      DefaultCombinedMetricICP<TransformT,CorrSearchT>(dst_points, dst_normals, src_points, src_normals, this->corr_search_, this->point_corr_weight_eval_, this->plane_corr_weight_eval_)
+            {}
         };
 
         template <class TransformT, class CorrSearchT>

--- a/include/cilantro/icp_single_transform_combined_metric.hpp
+++ b/include/cilantro/icp_single_transform_combined_metric.hpp
@@ -27,11 +27,33 @@ namespace cilantro {
                                          PointToPointCorrWeightEvaluatorT &point_corr_eval,
                                          PointToPlaneCorrWeightEvaluatorT &plane_corr_eval)
                 : Base(corr_engine),
-                  dst_points_(dst_p), dst_normals_(dst_n), src_points_(src_p),
+                  dst_points_(dst_p), dst_normals_(dst_n), src_points_(src_p), src_normals_(0),
                   max_optimization_iterations_(1), optimization_convergence_tol_((typename TransformT::Scalar)1e-5),
                   point_to_point_weight_((typename TransformT::Scalar)0.0), point_to_plane_weight_((typename TransformT::Scalar)1.0),
                   point_corr_eval_(point_corr_eval), plane_corr_eval_(plane_corr_eval),
-                  src_points_trans_(src_points_.rows(), src_points_.cols())
+                  src_points_trans_(src_points_.rows(), src_points_.cols()),
+                  dst_mean_(dst_points_.rowwise().mean()), src_mean_(src_points_.rowwise().mean()),
+                  has_source_normals_(false)
+        {
+            this->transform_init_.setIdentity();
+        }
+
+        CombinedMetricSingleTransformICP(const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &dst_p,
+                                         const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &dst_n,
+                                         const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &src_p,
+                                         const ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> &src_n,
+                                         CorrespondenceSearchEngineT &corr_engine,
+                                         PointToPointCorrWeightEvaluatorT &point_corr_eval,
+                                         PointToPlaneCorrWeightEvaluatorT &plane_corr_eval)
+                : Base(corr_engine),
+                  dst_points_(dst_p), dst_normals_(dst_n), src_points_(src_p), src_normals_(src_n),
+                  max_optimization_iterations_(1), optimization_convergence_tol_((typename TransformT::Scalar)1e-5),
+                  point_to_point_weight_((typename TransformT::Scalar)0.0), point_to_plane_weight_((typename TransformT::Scalar)1.0),
+                  point_corr_eval_(point_corr_eval), plane_corr_eval_(plane_corr_eval),
+                  src_points_trans_(src_points_.rows(), src_points_.cols()),
+                  src_normals_trans_(src_points_.rows(), src_points_.cols()),
+                  dst_mean_(dst_points_.rowwise().mean()), src_mean_(src_points_.rowwise().mean()),
+                  has_source_normals_(true)
         {
             this->transform_init_.setIdentity();
         }
@@ -76,6 +98,7 @@ namespace cilantro {
         ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> dst_points_;
         ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> dst_normals_;
         ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> src_points_;
+        ConstVectorSetMatrixMap<typename TransformT::Scalar,TransformT::Dim> src_normals_;
 
         size_t max_optimization_iterations_;
         typename TransformT::Scalar optimization_convergence_tol_;
@@ -86,6 +109,12 @@ namespace cilantro {
         PointToPlaneCorrespondenceWeightEvaluator& plane_corr_eval_;
 
         VectorSet<typename TransformT::Scalar,TransformT::Dim> src_points_trans_;
+        VectorSet<typename TransformT::Scalar,TransformT::Dim> src_normals_trans_;
+
+        Vector<typename TransformT::Scalar,TransformT::Dim> dst_mean_;
+        Vector<typename TransformT::Scalar,TransformT::Dim> src_mean_;
+
+        bool has_source_normals_;
 
         // ICP interface
         inline void initializeComputation() {}
@@ -97,10 +126,15 @@ namespace cilantro {
 
         void updateEstimate() {
             transformPoints(this->transform_, src_points_, src_points_trans_);
-
             CorrespondenceSearchCombinedMetricAdaptor<CorrespondenceSearchEngineT> corr_getter_proxy(this->correspondence_search_engine_);
             TransformT tform_iter;
-            estimateTransformCombinedMetric(dst_points_, dst_normals_, src_points_trans_, corr_getter_proxy.getPointToPointCorrespondences(), point_to_point_weight_, corr_getter_proxy.getPointToPlaneCorrespondences(), point_to_plane_weight_, tform_iter, max_optimization_iterations_, optimization_convergence_tol_, point_corr_eval_, plane_corr_eval_);
+
+            if (has_source_normals_) {
+                transformNormals(this->transform_, src_normals_, src_normals_trans_);
+                estimateTransformSymmetricMetric(dst_points_, dst_normals_, src_points_trans_, src_normals_trans_, corr_getter_proxy.getPointToPointCorrespondences(), point_to_point_weight_, corr_getter_proxy.getPointToPlaneCorrespondences(), point_to_plane_weight_, tform_iter, max_optimization_iterations_, optimization_convergence_tol_, point_corr_eval_, plane_corr_eval_, dst_mean_, this->transform_ * src_mean_);
+            } else {
+                estimateTransformCombinedMetric(dst_points_, dst_normals_, src_points_trans_, corr_getter_proxy.getPointToPointCorrespondences(), point_to_point_weight_, corr_getter_proxy.getPointToPlaneCorrespondences(), point_to_plane_weight_, tform_iter, max_optimization_iterations_, optimization_convergence_tol_, point_corr_eval_, plane_corr_eval_, dst_mean_, this->transform_ * src_mean_);
+            }
 
             this->transform_ = tform_iter*this->transform_;
             if (int(Base::Transform::Mode) == int(Eigen::Isometry)) {
@@ -118,11 +152,14 @@ namespace cilantro {
             KDTree<typename TransformT::Scalar,TransformT::Dim,KDTreeDistanceAdaptors::L2> dst_tree(dst_points_);
             Neighbor<typename TransformT::Scalar> nn;
             Vector<typename TransformT::Scalar,TransformT::Dim> src_p_trans;
+            Vector<typename TransformT::Scalar,TransformT::Dim> normal;
 #pragma omp parallel for shared (res) private (nn, src_p_trans)
             for (size_t i = 0; i < src_points_.cols(); i++) {
                 src_p_trans.noalias() = this->transform_*src_points_.col(i);
                 dst_tree.nearestNeighborSearch(src_p_trans, nn);
-                typename TransformT::Scalar point_to_plane_dist = dst_normals_.col(nn.index).dot(dst_points_.col(nn.index) - src_p_trans);
+                normal = dst_normals_.col(nn.index);
+                if (has_source_normals_) normal += src_normals_.col(i);
+                typename TransformT::Scalar point_to_plane_dist = normal.dot(dst_points_.col(nn.index) - src_p_trans);
                 res[i] = point_to_point_weight_*(dst_points_.col(nn.index) - src_p_trans).squaredNorm() + point_to_plane_weight_*point_to_plane_dist*point_to_plane_dist;
             }
             return res;


### PR DESCRIPTION
This is a proposal to add symmetric transform estimation to the existing `CombinedMetricSingleTransformICP` interface. Adding a new class probably causes significant code duplication but doesn't have the branching. Not sure if this is the way to go?

Also adds the offsetting by the mean to the transform estimation. We still deduct the mean every call since the ICP implementation uses `ConstVectorSetMatrixMap`. An alternative would be to store a centered copy of the data in the class.

Some quick preliminary tests reveal that the new method is more accurate (~order of magnitude on my example) and may convergence in less or equally many iterations as normal based ICP, depending on weighting of objectives.

Nit: @kzampog what formatting guideline are you using? I feel that I sometimes deviate from it, but would prefer consistency with the rest of the code base.